### PR TITLE
Add VPS deploy workflow + Express runtime

### DIFF
--- a/.deploy/package.json
+++ b/.deploy/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "angjobs-web",
+  "private": true,
+  "scripts": { "start": "node server.js" },
+  "dependencies": { "express": "^4.21.0" }
+}

--- a/.deploy/server.js
+++ b/.deploy/server.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || '127.0.0.1';
+
+// www → apex 301
+app.use((req, res, next) => {
+  const host = req.headers.host || '';
+  if (host.startsWith('www.')) {
+    const naked = host.replace(/^www\./, '');
+    res.writeHead(301, { Location: `https://${naked}${req.url}` });
+    return res.end();
+  }
+  next();
+});
+
+// Security headers
+app.use((req, res, next) => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  next();
+});
+
+// Static files
+app.use(express.static(__dirname, {
+  extensions: ['html'],
+  setHeaders: (res, filepath) => {
+    if (/\.(?:js|css)$/.test(filepath)) {
+      res.setHeader('Cache-Control', 'no-cache');
+    }
+  }
+}));
+
+// 404
+app.use((req, res) => {
+  const fallback = path.join(__dirname, '404.html');
+  res.status(404).sendFile(fallback, err => {
+    if (err) res.status(404).send('Not Found');
+  });
+});
+
+app.listen(PORT, HOST, () => {
+  console.log(`AngJobs running at http://${HOST}:${PORT}`);
+});

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -1,0 +1,57 @@
+name: Deploy AngJobs to VPS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  SERVICE: angjobs-web
+  REMOTE_PATH: /opt/angjobs
+  BUILD_OUTPUT: src/.vuepress/dist
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.14.0'
+
+      - name: Install
+        run: npm ci
+
+      - name: Build VuePress
+        run: npm run docs:build
+
+      - name: Inject deploy server
+        run: |
+          cp .deploy/server.js ${{ env.BUILD_OUTPUT }}/
+          cp .deploy/package.json ${{ env.BUILD_OUTPUT }}/
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts
+
+      - name: rsync
+        run: |
+          rsync -az --delete --exclude=node_modules \
+            ./${{ env.BUILD_OUTPUT }}/ \
+            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:${{ env.REMOTE_PATH }}/
+
+      - name: Restart + smoke
+        run: |
+          ssh ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} "
+            cd ${{ env.REMOTE_PATH }} && npm install --omit=dev &&
+            systemctl restart ${{ env.SERVICE }}
+          "
+          sleep 3
+          ssh ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} "
+            systemctl is-active ${{ env.SERVICE }} && \
+            curl -fsS -o /dev/null -w 'index: HTTP %{http_code}\n' http://127.0.0.1:5260/
+          "


### PR DESCRIPTION
## Summary
- Replaces the Azure Static Web Apps workflow with a self-hosted deploy to the Hetzner VPS
- Adds an Express runtime (server.js + package.json) injected into the VuePress build output at deploy time

## Context
The AngJobs SWA (`black-glacier-0d67e0703.5.azurestaticapps.net`) was deleted during the broader Azure→Hetzner migration. This PR puts the deploy back into a working state by:
1. Building the same `npm run docs:build` artifact as before (Node 20, VuePress 2, output at `src/.vuepress/dist/`)
2. Copying `.deploy/server.js` + `.deploy/package.json` into the build output
3. rsyncing to `/opt/angjobs/` on `77.42.86.33` over SSH
4. Restarting `angjobs-web.service` (systemd)

The site is already serving the correct content (built and deployed manually as part of the migration); merging this just makes future pushes auto-deploy.

## Required secrets
Already added to the repo by the migration:
- `VPS_HOST` = 77.42.86.33
- `VPS_USER` = root
- `VPS_SSH_KEY` = dedicated `vps-deploy-github` ed25519 key

## Test plan
- [ ] Merge to main
- [ ] Watch the workflow run; expect ~2 min total (npm ci dominates)
- [ ] Verify https://angjobs.com/ stays HTTP 200 after the deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)