### PR TITLE
Enable Sign in with GitHub on /admin

### DIFF
--- a/site.config.json
+++ b/site.config.json
@@ -2,6 +2,7 @@
   "site": {
     "title": "AngJobs",
     "url": "https://angjobs.com",
+    "oauthUrl": "https://plain-oauth-angjobs.victorantos.workers.dev",
     "description": "Find your next hacker job from Hacker News monthly threads. Browse the latest tech jobs, remote positions, and startup opportunities.",
     "language": "en",
     "theme": "angjobs",


### PR DESCRIPTION
Adds `site.oauthUrl` pointing at the dedicated Worker `plain-oauth-angjobs` (ALLOWED_ORIGIN=https://angjobs.com, reusing the `plain-cms-admin` App). Callback URL + repo access already set on the App. On deploy, `/admin` shows a one-click **Sign in with GitHub** button; the paste-a-token path stays available. Verified: build green (1714 pages), `oauthUrl` present in `dist/api/site.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HbHTfdpodpvtEAjZWLf6x